### PR TITLE
fixes for ci

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -3,6 +3,17 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        required: true
+        default: "warning"
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
 
 env:
   DOTNET_VERSION: "8.0.x"
@@ -10,9 +21,13 @@ env:
 jobs:
   Tests:
     uses: ./.github/workflows/tests.yml
+
   publish:
     needs: Tests
     name: build_package
+    permissions:
+      packages: write
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
@@ -25,7 +40,7 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: restore cached dependencies
+      - name: Restore cached dependencies
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
@@ -50,14 +65,18 @@ jobs:
 
           # Pack files
           7z a -tzip "${release_name}.zip" "./bin/YTINFOReader.dll"
-          echo "::set-output name=release_name::${release_name}"
-          echo "::set-output name=release_tag::${tag}"
-          echo "::set-output name=filename::${release_name}.zip"
+
+          # Set outputs using environment file
+          {
+            echo "release_name=${release_name}"
+            echo "release_tag=${tag}"
+            echo "filename=${release_name}.zip"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Release
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.GH_TOKEN }}"
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           title: "${{ steps.create_package.outputs.release_tag }}"
           automatic_release_tag: "${{ steps.create_package.outputs.release_tag }}"
           prerelease: true

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 name: "yt-dlp Info Reader"
 guid: "83b77e24-9fce-4ee0-a794-73fdfa972e64"
-version: "1.4.0.0"
+version: "1.5.0.0"
 targetAbi: "10.10.6.0"
 framework: "net8.0"
 owner: "arabcoders"


### PR DESCRIPTION
This pull request updates the build and release workflows, improves output handling in GitHub Actions, and increments the application version. The most significant changes include adding a manual workflow trigger, updating output handling to use the `$GITHUB_OUTPUT` environment file, and upgrading the application version.

### Workflow Improvements:
* [`.github/workflows/build-validation.yml`](diffhunk://#diff-e8e2b3eabf9f86cec2c609d61c5152b210e051fcf96422d90332c37c35edb585R6-R30): Added a `workflow_dispatch` trigger with an input for `logLevel` to allow manual triggering of the workflow with configurable log levels.
* [`.github/workflows/build-validation.yml`](diffhunk://#diff-e8e2b3eabf9f86cec2c609d61c5152b210e051fcf96422d90332c37c35edb585R6-R30): Updated the permissions for the `publish` job to enable writing to `packages` and `contents`.

### Output Handling Enhancements:
* [`.github/workflows/build-validation.yml`](diffhunk://#diff-e8e2b3eabf9f86cec2c609d61c5152b210e051fcf96422d90332c37c35edb585L53-R79): Replaced deprecated `::set-output` commands with the `$GITHUB_OUTPUT` environment file for setting outputs like `release_name`, `release_tag`, and `filename`.

### Miscellaneous Updates:
* [`.github/workflows/build-validation.yml`](diffhunk://#diff-e8e2b3eabf9f86cec2c609d61c5152b210e051fcf96422d90332c37c35edb585L28-R43): Corrected the casing of a step name from "restore cached dependencies" to "Restore cached dependencies" for consistency.

### Version Upgrade:
* [`build.yaml`](diffhunk://#diff-2f7f69286606c0ff1642fac8ecb40ee91874b65bb544af172e32552c91a44799L3-R3): Incremented the application version from `1.4.0.0` to `1.5.0.0`.